### PR TITLE
Add automated QA.

### DIFF
--- a/src/primo-gateway-build-role.ts
+++ b/src/primo-gateway-build-role.ts
@@ -175,6 +175,16 @@ export class PrimoGatewayBuildRole extends Role {
         actions: ['ssm:GetParametersByPath', 'ssm:GetParameter', 'ssm:GetParameters'],
       }),
     )
+
+    // Allow creating parameters (and delete in case of stack rollback)
+    this.addToPolicy(
+      new PolicyStatement({
+        resources: [
+          Fn.sub('arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/all/primo-gateway/*'),
+        ],
+        actions: ['ssm:PutParameter', 'ssm:DeleteParameter', 'ssm:AddTagsToResource', 'ssm:RemoveTagsFromResource'],
+      }),
+    )
   }
 }
 

--- a/src/primo-gateway-pipeline-stack.ts
+++ b/src/primo-gateway-pipeline-stack.ts
@@ -13,6 +13,7 @@ import { SecretValue } from '@aws-cdk/core'
 import { ArtifactBucket, PipelineNotifications, SlackApproval } from '@ndlib/ndlib-cdk'
 import PrimoGatewayBuildProject from './primo-gateway-build-project'
 import PrimoGatewayBuildRole from './primo-gateway-build-role'
+import PrimoGatewayQaProject from './primo-gateway-qa-project'
 
 const stages = ['test', 'prod']
 
@@ -109,6 +110,18 @@ export default class PrimoGatewayPipelineStack extends cdk.Stack {
       environmentVariables: actionEnvironment,
     })
 
+    // AUTOMATED QA
+    const qaProject = new PrimoGatewayQaProject(this, 'QAProject', {
+      stage: 'test',
+      role: codebuildRole,
+    })
+    const smokeTestsAction = new CodeBuildAction({
+      input: appSourceArtifact,
+      project: qaProject,
+      actionName: 'SmokeTests',
+      runOrder: 98,
+    })
+
     // APPROVAL
     const approvalTopic = new sns.Topic(this, 'PipelineApprovalTopic', {
       displayName: 'PipelineApprovalTopic',
@@ -129,7 +142,7 @@ export default class PrimoGatewayPipelineStack extends cdk.Stack {
     // TEST STAGE
     pipeline.addStage({
       stageName: 'DeployToTest',
-      actions: [deployToTestAction, manualApprovalAction],
+      actions: [deployToTestAction, smokeTestsAction, manualApprovalAction],
     })
 
     // DEPLOY TO PROD
@@ -146,10 +159,22 @@ export default class PrimoGatewayPipelineStack extends cdk.Stack {
       environmentVariables: actionEnvironment,
     })
 
+    // AUTOMATED QA
+    const prodQaProject = new PrimoGatewayQaProject(this, 'QAProjectProd', {
+      stage: 'prod',
+      role: codebuildRole,
+    })
+    const prodSmokeTestsAction = new CodeBuildAction({
+      input: appSourceArtifact,
+      project: prodQaProject,
+      actionName: 'SmokeTests',
+      runOrder: 98,
+    })
+
     // PROD STAGE
     pipeline.addStage({
       stageName: 'DeployToProd',
-      actions: [deployToProdAction],
+      actions: [deployToProdAction, prodSmokeTestsAction],
     })
   }
 }

--- a/src/primo-gateway-qa-project.ts
+++ b/src/primo-gateway-qa-project.ts
@@ -1,0 +1,51 @@
+import { PipelineProject, BuildSpec, BuildEnvironmentVariableType, LinuxBuildImage } from '@aws-cdk/aws-codebuild'
+import { Role } from '@aws-cdk/aws-iam'
+import { Construct } from '@aws-cdk/core'
+
+export interface IPrimoGatewayQaProjectProps {
+  readonly stage: string
+  readonly role: Role
+}
+
+export class PrimoGatewayQaProject extends PipelineProject {
+  constructor(scope: Construct, id: string, props: IPrimoGatewayQaProjectProps) {
+    const paramStorePath = `/all/primo-gateway/${props.stage}`
+    const pipelineProps = {
+      role: props.role,
+      environment: {
+        buildImage: LinuxBuildImage.STANDARD_4_0,
+        environmentVariables: {
+          API_URL: {
+            value: `${paramStorePath}/api-url`,
+            type: BuildEnvironmentVariableType.PARAMETER_STORE,
+          },
+          CI: { value: 'true', type: BuildEnvironmentVariableType.PLAINTEXT },
+        },
+      },
+      buildSpec: BuildSpec.fromObject({
+        version: '0.2',
+        phases: {
+          install: {
+            'runtime-versions': {
+              nodejs: '12.x',
+            },
+            commands: [
+              'npm install -g newman',
+              'echo "Ensure that the Newman spec is readable"',
+              'chmod -R 755 ./tests/postman/*',
+            ],
+          },
+          build: {
+            commands: [
+              'echo "Beginning tests at `date`"',
+              `newman run ./tests/postman/qa_collection.json --env-var primoGatewayApiUrl=$API_URL`,
+            ],
+          },
+        },
+      }),
+    }
+    super(scope, id, pipelineProps)
+  }
+}
+
+export default PrimoGatewayQaProject

--- a/src/primo-gateway-stack.ts
+++ b/src/primo-gateway-stack.ts
@@ -98,7 +98,7 @@ export default class PrimoGatewayStack extends cdk.Stack {
       validateRequestParameters: true,
     })
 
-    const defaultMethodOptions = {
+    const authorizationMethodOptions = {
       authorizationType: apigateway.AuthorizationType.CUSTOM,
       authorizer: new apigateway.TokenAuthorizer(this, 'JwtAuthorizer', {
         handler: lambda.Function.fromFunctionArn(
@@ -120,9 +120,6 @@ export default class PrimoGatewayStack extends cdk.Stack {
       resources: [
         {
           pathPart: 'query',
-          options: {
-            defaultMethodOptions: defaultMethodOptions,
-          },
           methods: [
             {
               httpMethod: 'GET',
@@ -133,7 +130,7 @@ export default class PrimoGatewayStack extends cdk.Stack {
         {
           pathPart: 'favorites',
           options: {
-            defaultMethodOptions: defaultMethodOptions,
+            defaultMethodOptions: authorizationMethodOptions,
           },
           methods: [
             {
@@ -143,6 +140,13 @@ export default class PrimoGatewayStack extends cdk.Stack {
           ],
         },
       ],
+    })
+
+    // Output API url to ssm so we can import it in the QA project
+    new StringParameter(this, 'ApiUrlParameter', {
+      parameterName: `${paramStorePath}/api-url`,
+      description: 'Path to root of the API gateway.',
+      stringValue: api.url,
     })
   }
 }


### PR DESCRIPTION
Also removed authorizer from the /query endpoint. I think it was there by mistake; there's no reason not to allow anonymous access considering an anonymous user can already hit the Primo API directly.