### PR TITLE
Don't include authorizer as default on the API resources.

### DIFF
--- a/src/primo-gateway-stack.ts
+++ b/src/primo-gateway-stack.ts
@@ -129,13 +129,11 @@ export default class PrimoGatewayStack extends cdk.Stack {
         },
         {
           pathPart: 'favorites',
-          options: {
-            defaultMethodOptions: authorizationMethodOptions,
-          },
           methods: [
             {
               httpMethod: 'GET',
               integration: new apigateway.LambdaIntegration(favoritesLambda),
+              options: authorizationMethodOptions,
             },
           ],
         },


### PR DESCRIPTION
Only on endpoints that we create specifically.

This is to prevent it from requiring authorization for the auto-generated OPTIONS endpoints.